### PR TITLE
Add symmetric key analysis utilities and catalog results

### DIFF
--- a/daily_check_2025-06-15.md
+++ b/daily_check_2025-06-15.md
@@ -1,0 +1,14 @@
+# Daily Check 2025-06-15
+
+## Test and Linter Results
+- `python -m py_compile $(git ls-files '*.py')` completed successfully.
+- `pytest -q` ran successfully with all tests passing.
+
+## TODO Review
+- Searched repository for "TODO" and found none within source files.
+
+
+### 2nd Run
+- `python -m py_compile $(git ls-files '*.py')` completed successfully.
+- `pytest -q` ran successfully with all tests passing.
+- No TODO items found.

--- a/greenwire/core/symm_analysis.py
+++ b/greenwire/core/symm_analysis.py
@@ -1,0 +1,68 @@
+import math
+from typing import List, Dict
+
+
+def key_entropy(data: bytes) -> float:
+    """Calculate Shannon entropy of key bytes."""
+    if not data:
+        return 0.0
+    length = len(data)
+    counts = [0] * 256
+    for b in data:
+        counts[b] += 1
+    entropy = 0.0
+    for c in counts:
+        if c:
+            p = c / length
+            entropy -= p * math.log2(p)
+    return entropy
+
+
+def weak_key_bits(data: bytes) -> List[int]:
+    """Return indexes of bytes with very low or high hamming weight."""
+    weak = []
+    for i, b in enumerate(data):
+        weight = bin(b).count("1")
+        if weight <= 2 or weight >= 6:
+            weak.append(i)
+    return weak
+
+
+def find_repeating_sequences(data: bytes, min_len: int = 2) -> List[bytes]:
+    """Detect simple repeating byte sequences in the key."""
+    patterns = []
+    length = len(data)
+    for l in range(min_len, min(4, length // 2) + 1):
+        for i in range(length - l):
+            segment = data[i:i + l]
+            if data.count(segment) > 1 and segment not in patterns:
+                patterns.append(segment)
+    return patterns
+
+
+def analyze_symmetric_key(data: bytes, key_type: str, *, min_entropy: float = 3.5) -> Dict:
+    """Analyze symmetric key material and return analysis information."""
+    info = {
+        "key_length": len(data) * 8,
+        "entropy_score": key_entropy(data),
+        "potential_weaknesses": []
+    }
+    if key_type == "DES" and len(data) != 8:
+        info["potential_weaknesses"].append(f"Invalid DES key length: {len(data)} bytes")
+    elif key_type == "AES" and len(data) not in [16, 24, 32]:
+        info["potential_weaknesses"].append(f"Invalid AES key length: {len(data)} bytes")
+
+    if info["entropy_score"] < min_entropy:
+        info["potential_weaknesses"].append(
+            f"Low entropy score: {info['entropy_score']:.2f}"
+        )
+
+    patterns = find_repeating_sequences(data)
+    if patterns:
+        info["potential_weaknesses"].append(f"Found {len(patterns)} repeating patterns")
+
+    weak = weak_key_bits(data)
+    if weak:
+        info["potential_weaknesses"].append(f"Found {len(weak)} weak key bits")
+
+    return info

--- a/greenwire/tests/test_symm_analysis.py
+++ b/greenwire/tests/test_symm_analysis.py
@@ -1,0 +1,17 @@
+import importlib.util
+from pathlib import Path
+
+_symm_path = Path(__file__).resolve().parents[1] / "core" / "symm_analysis.py"
+spec = importlib.util.spec_from_file_location("symm_analysis", _symm_path)
+symm_analysis = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(symm_analysis)
+
+
+def test_entropy_low_detected():
+    info = symm_analysis.analyze_symmetric_key(b"\x00" * 16, "AES")
+    assert any("Low entropy" in w for w in info["potential_weaknesses"])
+
+
+def test_valid_key_length():
+    info = symm_analysis.analyze_symmetric_key(bytes(range(16)), "AES")
+    assert info["key_length"] == 128


### PR DESCRIPTION
## Summary
- add reusable symmetric key analysis functions
- integrate new analysis into `greenwire-brute.py`
- store extracted key data with new `catalog_results` method
- record daily test results
- add tests for symmetric key analysis

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684eec77483083298b818df5b617185e