### PR TITLE
Add JCOP CLI support and daily test log

### DIFF
--- a/daily_check_2025-06-24.md
+++ b/daily_check_2025-06-24.md
@@ -1,0 +1,9 @@
+# Daily Check 2025-06-24
+
+## Test and Linter Results
+- `python -m py_compile $(git ls-files '*.py')` completed successfully.
+- `pytest -q` ran successfully with all tests passing.
+
+## TODO Review
+- Searched repository for "TODO" and found none within source files.
+- STUBS_TODO.md still lists several TODO items.

--- a/greenwire/__init__.py
+++ b/greenwire/__init__.py
@@ -6,10 +6,12 @@ from .core.nfc_iso import (
     ISO18092ReaderWriter,
 )
 from .nfc_vuln import scan_nfc_vulnerabilities
+from .core.jcop import JCOPManager
 
 __all__ = [
     "ISO14443ReaderWriter",
     "ISO15693ReaderWriter",
     "ISO18092ReaderWriter",
     "scan_nfc_vulnerabilities",
+    "JCOPManager",
 ]

--- a/greenwire/core/jcop.py
+++ b/greenwire/core/jcop.py
@@ -1,0 +1,23 @@
+from typing import Tuple
+from smartcard.System import readers
+
+class JCOPManager:
+    """Minimal JCOP card helper for demo purposes."""
+
+    GET_DATA_OS_VERSION = [0x80, 0xCA, 0x9F, 0x7F, 0x00]
+
+    def __init__(self) -> None:
+        self.connection = None
+
+    def connect(self) -> None:
+        available = readers()
+        if not available:
+            raise RuntimeError("No smart card readers available")
+        self.connection = available[0].createConnection()
+        self.connection.connect()
+
+    def get_os_version(self) -> Tuple[list, int, int]:
+        if not self.connection:
+            self.connect()
+        data, sw1, sw2 = self.connection.transmit(self.GET_DATA_OS_VERSION)
+        return data, sw1, sw2

--- a/greenwire/menu_cli.py
+++ b/greenwire/menu_cli.py
@@ -20,7 +20,9 @@ GREENWIRE Menu
 7. Read NFC block
 8. Write NFC block
 9. Show NFC tag UID
-10. Quit
+10. JCOP OS version
+11. Fuzz JCOP
+12. Quit
 """
 
 
@@ -81,6 +83,25 @@ def main() -> None:
             uid = processor.read_uid()
             print(f"UID: {uid}")
         elif choice == "10":
+            from greenwire.core.jcop import JCOPManager
+            mgr = JCOPManager()
+            try:
+                data, sw1, sw2 = mgr.get_os_version()
+                print("JCOP OS version:", data, hex(sw1), hex(sw2))
+            except Exception as exc:
+                print("Error accessing JCOP card:", exc)
+        elif choice == "11":
+            from greenwire.core.jcop import JCOPManager
+            mgr = JCOPManager()
+            try:
+                mgr.connect()
+                fuzzer = SmartcardFuzzer({"dry_run": True})
+                results = fuzzer.fuzz_contactless(["A0000000031010"], iterations=1)
+                for r in results:
+                    print(r)
+            except Exception as exc:
+                print("JCOP fuzzing failed:", exc)
+        elif choice == "12":
             break
         else:
             print("Invalid choice")


### PR DESCRIPTION
## Summary
- integrate `JCOPManager` helper to talk to JCOP cards
- export `JCOPManager` in the package
- extend CLI with options for JCOP version query and fuzzing
- add daily test log for 2025‑06‑24

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a4135c3d08329a0d485aee504fc30