### PR TITLE
Fix auth check and docs, add TLV parser test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 I replaced the original Perl implementation with a Python version for now.
 ---
 
-### Python Unified CLI: greenwire.py
+### Python Unified CLI: greenwtest1.py
 
-`greenwire.py` is a unified command-line tool for both EMV card issuing and SMS PDU building. It wraps the Python EMV issuer and the Perl SMS CLI.
+`greenwtest1.py` is a unified command-line tool for both EMV card issuing and SMS PDU building. It wraps the Python EMV issuer and the Perl SMS CLI.
 Additional features and programs will be added over time.
 
 GREENWIRE CLI Interface
@@ -157,7 +157,7 @@ assumes a contact interface.
 #### Notes
 - Place your Perl modules and `greenwire-cli.pl` in the same directory or adjust the path.
 - For Google Drive upload, ensure `service-account.json` is present.
-- All EMV and SMS logic is unified in `greenwire.py` for convenience.
+- All EMV and SMS logic is unified in `greenwtest1.py` for convenience.
 
 ## Supported Standards
 

--- a/greenwire-brute.py
+++ b/greenwire-brute.py
@@ -1588,7 +1588,7 @@ class SmartcardFuzzerBrute:
         sw, resp = None, None  # Initialize variables
         try:
             challenge_sw, challenge = self.get_challenge()
-            if challenge_sw == 0x9000:
+            if challenge_sw == (0x90, 0x00):
                 sw, resp = self.internal_authenticate(challenge)
         except Exception as e:
             logging.error(f"Error during offline authentication: {e}")

--- a/greenwire/tests/test_tlv_parser.py
+++ b/greenwire/tests/test_tlv_parser.py
@@ -1,0 +1,21 @@
+import importlib.util
+from pathlib import Path
+
+_fuzzer_path = Path(__file__).resolve().parents[1] / "core" / "fuzzer.py"
+spec = importlib.util.spec_from_file_location("fuzzer", _fuzzer_path)
+fuzzer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(fuzzer)
+
+
+def test_parse_and_find_tag():
+    data = bytes.fromhex("9F02060000000100009F110101")
+    objs = fuzzer.TLVParser.parse(data)
+    assert len(objs) == 2
+    assert objs[0].tag == bytes.fromhex("9F02")
+    assert objs[0].length == 6
+    assert objs[0].value == bytes.fromhex("000000010000")
+    assert objs[1].tag == bytes.fromhex("9F11")
+    assert objs[1].value == bytes.fromhex("01")
+
+    val = fuzzer.TLVParser.find_tag(data, "9F02")
+    assert val == bytes.fromhex("000000010000")

--- a/greenwtest1.py
+++ b/greenwtest1.py
@@ -6,7 +6,7 @@ Combines features from greenwire-brute.py, improved variant, and fuzzer.py into
 one efficient, Windows-friendly tool.
 
 Usage:
-  greenwire.py [options] --mode <mode> [--type <type>] [--count N]
+  greenwtest1.py [options] --mode <mode> [--type <type>] [--count N]
 
 Modes:
   standard      Basic EMV protocol testing


### PR DESCRIPTION
## Summary
- fix status word check in card authentication
- reference `greenwtest1.py` throughout docs
- fix usage info in the CLI script
- add TLVParser unit test

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6847d65a98948329a3ef41c79b82ef46