### PR TITLE
Add tree-based CLI and cleanup

### DIFF
--- a/greenwire/core/symm_analysis.py
+++ b/greenwire/core/symm_analysis.py
@@ -32,15 +32,17 @@ def find_repeating_sequences(data: bytes, min_len: int = 2) -> List[bytes]:
     """Detect simple repeating byte sequences in the key."""
     patterns = []
     length = len(data)
-    for l in range(min_len, min(4, length // 2) + 1):
-        for i in range(length - l):
-            segment = data[i:i + l]
+    for seg_len in range(min_len, min(4, length // 2) + 1):
+        for i in range(length - seg_len):
+            segment = data[i:i + seg_len]
             if data.count(segment) > 1 and segment not in patterns:
                 patterns.append(segment)
     return patterns
 
 
-def analyze_symmetric_key(data: bytes, key_type: str, *, min_entropy: float = 3.5) -> Dict:
+def analyze_symmetric_key(
+    data: bytes, key_type: str, *, min_entropy: float = 3.5
+) -> Dict:
     """Analyze symmetric key material and return analysis information."""
     info = {
         "key_length": len(data) * 8,
@@ -48,9 +50,13 @@ def analyze_symmetric_key(data: bytes, key_type: str, *, min_entropy: float = 3.
         "potential_weaknesses": []
     }
     if key_type == "DES" and len(data) != 8:
-        info["potential_weaknesses"].append(f"Invalid DES key length: {len(data)} bytes")
+        info["potential_weaknesses"].append(
+            f"Invalid DES key length: {len(data)} bytes"
+        )
     elif key_type == "AES" and len(data) not in [16, 24, 32]:
-        info["potential_weaknesses"].append(f"Invalid AES key length: {len(data)} bytes")
+        info["potential_weaknesses"].append(
+            f"Invalid AES key length: {len(data)} bytes"
+        )
 
     if info["entropy_score"] < min_entropy:
         info["potential_weaknesses"].append(
@@ -59,7 +65,9 @@ def analyze_symmetric_key(data: bytes, key_type: str, *, min_entropy: float = 3.
 
     patterns = find_repeating_sequences(data)
     if patterns:
-        info["potential_weaknesses"].append(f"Found {len(patterns)} repeating patterns")
+        info["potential_weaknesses"].append(
+            f"Found {len(patterns)} repeating patterns"
+        )
 
     weak = weak_key_bits(data)
     if weak:

--- a/greenwire/menu_cli.py
+++ b/greenwire/menu_cli.py
@@ -34,6 +34,7 @@ GREENWIRE Menu
 21. Quit
 """
 
+
 # ---------------------------------------------------------------------------
 # Helper functions for each menu option
 # ---------------------------------------------------------------------------
@@ -42,7 +43,10 @@ def dump_atr() -> None:
     """Attempt to print the card ATR/ATS if available."""
     reader = ISO14443ReaderWriter()
     if reader.connect():
-        atr = getattr(reader.tag, "ats", None) or getattr(reader.tag, "atr", None)
+        atr = (
+            getattr(reader.tag, "ats", None)
+            or getattr(reader.tag, "atr", None)
+        )
         if atr:
             print(f"ATR/ATS: {atr.hex()}")
         else:
@@ -116,7 +120,10 @@ def detect_card_os() -> None:
     """Attempt to identify the card OS based on ATR patterns."""
     reader = ISO14443ReaderWriter()
     if reader.connect():
-        atr = getattr(reader.tag, "ats", None) or getattr(reader.tag, "atr", None)
+        atr = (
+            getattr(reader.tag, "ats", None)
+            or getattr(reader.tag, "atr", None)
+        )
         if atr and atr.startswith(bytes.fromhex("3B8F")):
             print(f"Detected card OS: JCOP (ATR {atr.hex()})")
         else:
@@ -128,6 +135,7 @@ def detect_card_os() -> None:
 # ---------------------------------------------------------------------------
 # Main interactive loop
 # ---------------------------------------------------------------------------
+
 
 def main() -> None:
     parser = argparse.ArgumentParser(description="GREENWIRE interactive menu")

--- a/greenwire/tree_menu_cli.py
+++ b/greenwire/tree_menu_cli.py
@@ -1,0 +1,134 @@
+"""Tree-based interactive CLI for GREENWIRE operations.
+
+This script presents a hierarchical menu where the user first selects a
+standard/card type and then chooses an action specific to that
+selection.  It reuses helpers from ``menu_cli`` and ``crypto_engine``.
+"""
+
+from __future__ import annotations
+
+import argparse
+from typing import Callable, Dict
+
+from greenwire.core.crypto_engine import generate_rsa_key, generate_ec_key
+from greenwire.core.nfc_emv import ContactlessEMVTerminal
+from greenwire.core.standards import Standard
+from greenwire.menu_cli import (
+    dump_atr,
+    dump_memory,
+    brute_force_pin,
+    fuzz_apdu,
+    fuzz_transaction,
+    scan_for_cards,
+    dump_filesystem,
+    export_data,
+    import_data,
+    reset_card,
+    detect_card_os,
+)
+from greenwire.core.backend import init_backend
+
+# ---------------------------------------------------------------------------
+# Action implementations
+# ---------------------------------------------------------------------------
+
+
+def _terminal_test() -> None:
+    """Perform a minimal EMV transaction as a terminal."""
+    terminal = ContactlessEMVTerminal(["A0000000031010"])
+    results = terminal.run()
+    for res in results:
+        print(res)
+
+
+def _atm_hsm_test() -> None:
+    """Placeholder for ATM/HSM specific tests."""
+    print("[SIMULATION] Running ATM/HSM test sequence")
+    _terminal_test()
+
+
+def _generate_cert() -> None:
+    """Generate a simple RSA and ECC test certificate pair."""
+    rsa_key = generate_rsa_key()
+    ecc_key = generate_ec_key()
+    print(f"Generated RSA modulus bits: {rsa_key.key_size}")
+    print(f"Generated ECC curve: {ecc_key.curve.name}")
+
+
+# Mapping of menu actions
+Action = Callable[[], None]
+
+MENU_TREE: Dict[str, Dict[str, tuple[str, Action]]] = {
+    Standard.EMV.value: {
+        "1": ("Terminal test", _terminal_test),
+        "2": ("ATM/HSM test", _atm_hsm_test),
+        "3": ("Generate certificates", _generate_cert),
+    },
+    "Card Ops": {
+        "1": ("Dump ATR", dump_atr),
+        "2": ("Dump memory", dump_memory),
+        "3": ("Brute force PIN", brute_force_pin),
+        "4": ("Fuzz APDU", fuzz_apdu),
+        "5": ("Fuzz transaction", fuzz_transaction),
+        "6": ("Scan for cards", scan_for_cards),
+        "7": ("Dump filesystem", dump_filesystem),
+        "8": ("Export DB", lambda: export_data(init_backend())),
+        "9": ("Import DB", import_data),
+        "10": ("Reset card", reset_card),
+        "11": ("Detect card OS", detect_card_os),
+    },
+}
+
+# ---------------------------------------------------------------------------
+# Menu helpers
+# ---------------------------------------------------------------------------
+
+
+def _print_menu(options: Dict[str, tuple[str, Action]]) -> None:
+    for key, (label, _) in sorted(options.items(), key=lambda x: int(x[0])):
+        print(f"{key}. {label}")
+
+
+def run_tree_cli() -> None:
+    """Entry point for the tree-based menu."""
+    parser = argparse.ArgumentParser(description="GREENWIRE tree menu")
+    parser.add_argument("--db", default="card_data.db")
+    args = parser.parse_args()
+
+    conn = init_backend(args.db)
+    while True:
+        print("\nSelect standard/card type:")
+        for i, std in enumerate(MENU_TREE, start=1):
+            print(f"{i}. {std}")
+        print("Q. Quit")
+        choice = input("Choice: ").strip().upper()
+        if choice == "Q":
+            break
+        try:
+            selected = list(MENU_TREE.keys())[int(choice) - 1]
+        except (IndexError, ValueError):
+            print("Invalid selection")
+            continue
+
+        actions = MENU_TREE[selected]
+        while True:
+            print(f"\n-- {selected} --")
+            _print_menu(actions)
+            print("B. Back")
+            opt = input("Select action: ").strip().upper()
+            if opt == "B":
+                break
+            action = actions.get(opt)
+            if not action:
+                print("Invalid option")
+                continue
+            label, func = action
+            print(f"[RUNNING] {label}")
+            if func in {export_data}:
+                func(conn)  # requires db connection
+            else:
+                func()
+
+
+if __name__ == "__main__":
+    run_tree_cli()


### PR DESCRIPTION
## Summary
- fix linter issues in symm_analysis and menu_cli
- add a new tree-based interactive CLI exposing card and standard options
- keep repo lint and tests green

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860df0601e88329b1cac2108184ebce