### PR TITLE
Add HSM emulator and daily test log

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,25 @@ Terminal emulation supports Dynamic Data Authentication (DDA) and can operate in
 
 See CLI help (`-h`) for all options.
 
+## HSM/ATM Emulator
+
+GREENWIRE ships with a lightweight HSM emulator inspired by modern
+Thales and Futurex devices. The `HSMEmulator` class can generate a
+signed EMV applet for testing terminal flows without physical HSM
+hardware:
+
+```python
+from greenwire import HSMEmulator
+
+hsm = HSMEmulator(issuer="Demo Bank")
+applet = hsm.generate_e_applet()
+print(applet.card)
+```
+
+The returned `EMVApplet` contains the generated card data, the RSA
+public modulus, and a signature that proves authenticity of the card
+details.
+
 ## Contact vs Contactless Cards
 
 Traditional **contact** smartcards follow the ISO 7816 specification and

--- a/daily_check_2025-06-29.md
+++ b/daily_check_2025-06-29.md
@@ -1,0 +1,8 @@
+# Daily Check 2025-06-29
+
+## Test and Linter Results
+- `python -m py_compile $(git ls-files '*.py')` completed successfully.
+- `pytest -q` ran successfully with all tests passing.
+
+## TODO Review
+- Searched repository for "TODO" and found none within source files.

--- a/greenwire/__init__.py
+++ b/greenwire/__init__.py
@@ -6,6 +6,7 @@ from .core.nfc_iso import (
     ISO18092ReaderWriter,
     AndroidReaderWriter,
 )
+from .core.hsm_emulator import HSMEmulator
 from .nfc_vuln import scan_nfc_vulnerabilities
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     "ISO15693ReaderWriter",
     "ISO18092ReaderWriter",
     "AndroidReaderWriter",
+    "HSMEmulator",
     "scan_nfc_vulnerabilities",
 ]

--- a/greenwire/core/hsm_emulator.py
+++ b/greenwire/core/hsm_emulator.py
@@ -1,0 +1,39 @@
+"""Simple HSM/ATM emulator for generating EMV applets."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Dict
+
+from .emv_generator import generate_card
+from .crypto_engine import generate_rsa_key, rsa_sign
+
+
+@dataclass
+class EMVApplet:
+    """Representation of a minimal EMV applet."""
+
+    card: Dict[str, str]
+    public_modulus: str
+    signature: bytes
+
+
+class HSMEmulator:
+    """Lightweight emulator inspired by modern HSMs."""
+
+    def __init__(self, issuer: str = "TEST BANK") -> None:
+        self.issuer = issuer
+        self._key = generate_rsa_key()
+
+    def generate_e_applet(self) -> EMVApplet:
+        """Generate EMV card data and sign it."""
+        card = generate_card(self.issuer)
+        data = f"{card['pan']}{card['expiry']}".encode()
+        signature = rsa_sign(self._key, data)
+        return EMVApplet(
+            card=card,
+            public_modulus=self._key.public_key().public_numbers().n.to_bytes(
+                self._key.key_size // 8, "big"
+            ).hex(),
+            signature=signature,
+        )

--- a/greenwire/tests/test_hsm_emulator.py
+++ b/greenwire/tests/test_hsm_emulator.py
@@ -1,0 +1,10 @@
+from greenwire.core.hsm_emulator import HSMEmulator
+
+
+def test_generate_e_applet():
+    hsm = HSMEmulator(issuer="BankX")
+    applet = hsm.generate_e_applet()
+    assert applet.card["issuer"] == "BankX"
+    assert "pan" in applet.card
+    assert isinstance(applet.public_modulus, str)
+    assert isinstance(applet.signature, bytes)

--- a/test_suite.py
+++ b/test_suite.py
@@ -41,25 +41,27 @@ class GreenWireTestSuite:
         
         try:
             result = subprocess.run(
-                cmd, 
-                capture_output=True, 
-                text=True, 
+                cmd,
+                capture_output=True,
+                text=True,
                 timeout=timeout,
-                cwd=self.base_path
+                cwd=self.base_path,
             )
-              if result.returncode == 0:
+            if result.returncode == 0:
                 self.test_results['passed'] += 1
                 logger.info(f"[PASS] {description}")
                 self.test_results['details'].append({
                     'test': description,
                     'status': 'PASSED',
                     'stdout': result.stdout,
-                    'stderr': result.stderr
+                    'stderr': result.stderr,
                 })
                 return True
             else:
                 self.test_results['failed'] += 1
-                error_msg = f"FAILED: {description} - Return code: {result.returncode}"
+                error_msg = (
+                    f"FAILED: {description} - Return code: {result.returncode}"
+                )
                 logger.error(error_msg)
                 self.test_results['errors'].append(error_msg)
                 self.test_results['details'].append({
@@ -67,7 +69,7 @@ class GreenWireTestSuite:
                     'status': 'FAILED',
                     'returncode': result.returncode,
                     'stdout': result.stdout,
-                    'stderr': result.stderr
+                    'stderr': result.stderr,
                 })
                 return False
                 


### PR DESCRIPTION
## Summary
- implement `HSMEmulator` to emulate basic Thales/Futurex behavior
- expose `HSMEmulator` in package `__init__`
- document usage in README
- fix indentation in `test_suite.py`
- add tests for new emulator
- add daily test log for 2025-06-29

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68618451be548329b75d235c315cd679