### PR TITLE
Add daily check log and document APDUs

### DIFF
--- a/daily_check_2025-06-29.md
+++ b/daily_check_2025-06-29.md
@@ -1,0 +1,8 @@
+# Daily Check 2025-06-29
+
+## Test and Linter Results
+- `python -m py_compile $(git ls-files '*.py')` completed successfully.
+- `pytest -q` failed due to missing modules (`cryptography`, `pexpect`, `PIL`).
+
+## TODO Review
+- Searched repository for "TODO" and found none within source files.


### PR DESCRIPTION
## Summary
- document APDU sequences used when communicating with NFC cards
- add a daily check entry for 2025‑06‑29

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` *(fails: ModuleNotFoundError: cryptography, pexpect, PIL)*

------
https://chatgpt.com/codex/tasks/task_e_6861cddead988329a77dfaffd18bc9cb