### PR TITLE
Add applet fuzzing emulator test

### DIFF
--- a/daily_check_2025-06-30.md
+++ b/daily_check_2025-06-30.md
@@ -1,0 +1,8 @@
+# Daily Check 2025-06-30
+
+## Test and Linter Results
+- `python -m py_compile $(git ls-files '*.py')` completed successfully.
+- `pytest -q` ran successfully with all tests passing.
+
+## TODO Review
+- Searched repository for "TODO" and found none within source files.

--- a/greenwire/core/fuzzer.py
+++ b/greenwire/core/fuzzer.py
@@ -1085,3 +1085,15 @@ class SmartcardFuzzer:
             results.extend(terminal.run())
 
         return results
+
+    def fuzz_applet_emulation(self, emulator, aid: str, iterations: int = 1) -> List[dict]:
+        """Fuzz an AID using a card emulator by issuing random APDUs."""
+        aid_bytes = bytes.fromhex(aid)
+        results: List[dict] = []
+        for _ in range(iterations):
+            select_resp = emulator.send_apdu(0x00, 0xA4, 0x04, 0x00, aid_bytes)
+            p1 = random.randint(0, 255)
+            p2 = random.randint(0, 255)
+            fuzz_resp = emulator.send_apdu(0x00, 0xB0, p1, p2, b"")
+            results.append({"aid": aid, "select": bytes(select_resp), "fuzz_resp": bytes(fuzz_resp)})
+        return results

--- a/greenwire/tests/test_applet_fuzzing.py
+++ b/greenwire/tests/test_applet_fuzzing.py
@@ -1,0 +1,26 @@
+import importlib.util
+from pathlib import Path
+import sys
+
+_fuzzer_path = Path(__file__).resolve().parents[1] / "core" / "fuzzer.py"
+sys.path.insert(0, str(_fuzzer_path.parents[2]))
+spec = importlib.util.spec_from_file_location("fuzzer", _fuzzer_path)
+fuzzer = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(fuzzer)
+
+
+class DummyEmulator:
+    def __init__(self):
+        self.commands = []
+
+    def send_apdu(self, cla, ins, p1, p2, data=b""):
+        self.commands.append((cla, ins, p1, p2, data))
+        return b"\x90\x00"
+
+
+def test_fuzz_applet_emulation(monkeypatch):
+    emulator = DummyEmulator()
+    sf = fuzzer.SmartcardFuzzer({"dry_run": True})
+    res = sf.fuzz_applet_emulation(emulator, "A0000000031010", iterations=2)
+    assert len(res) == 2
+    assert emulator.commands[0][1] == 0xA4


### PR DESCRIPTION
## Summary
- implement `fuzz_applet_emulation` for SmartcardFuzzer
- test applet fuzzing with a dummy emulator
- record today's successful test run

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6863201324988329a809bc59dbcb6ef9