### PR TITLE
docs: clarify menu CLI usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,18 @@ python greenwire.py install-cap --cap-file myapplet.cap --tool gpp --aid A000000
 
 ---
 
+## Simple Menu Interface
+
+For quick experiments, run the lightweight menu-based wrapper:
+
+```bash
+python menu_cli.py
+```
+
+This script offers an interactive menu for common tasks built on top of the main `greenwire` toolkit.
+
+---
+
 ## Field/Production Notes
 
 - For field testing, always use the `--hardware` and `--profile` options to select the correct terminal/HSM profile (e.g., `pcsc`, `nfc`, `hsm`).

--- a/menu_cli.py
+++ b/menu_cli.py
@@ -1,8 +1,11 @@
+"""Minimal menu-driven interface for the GREENWIRE toolkit."""
+
 import logging
 from greenwire import GreenwireSuperTouch
 
 
 def display_menu():
+    """Print the available command-line menu options."""
     print("\nGREENWIRE CLI Menu")
     print("1. SUPERTOUCH Operation")
     print("2. Execute JavaCard .cap Tests")
@@ -10,6 +13,7 @@ def display_menu():
 
 
 def execute_javacard_tests():
+    """Run a series of JavaCard .cap tests using the SUPERTOUCH tool."""
     logging.info("Starting JavaCard .cap tests...")
     supertouch_tool = GreenwireSuperTouch()
 
@@ -29,6 +33,7 @@ def execute_javacard_tests():
 
 
 def main():
+    """Entry point for the interactive CLI menu."""
     logging.basicConfig(
         level=logging.INFO,
         filename="greenwire_cli_log.txt",


### PR DESCRIPTION
## Summary
- document the lightweight `menu_cli.py` interface and its functions
- mention simple menu wrapper in the README for quick experiments

## Testing
- `flake8`
- `pytest` *(fails: ModuleNotFoundError: No module named 'greenwire'; ModuleNotFoundError: No module named 'smartcard'; SyntaxError in greenwtest1.py)*

------
https://chatgpt.com/codex/tasks/task_e_689bd37ee234832990ef9047e6a5e17e